### PR TITLE
@coderabbitai

### DIFF
--- a/src/server/api/routers/files.ts
+++ b/src/server/api/routers/files.ts
@@ -401,7 +401,10 @@ async function removeInternalQuestionFile({
           .where(eq(questionTrueFalse.questionId, questionId))
       )[0];
       if (!tFQuestions) {
-        throw new Error("Question not found");
+        return err({
+          type: deleteInternalQuestionFileErrorTypes.NotFound,
+          message: "Question not found",
+        });
       }
       switch (answerId) {
         case tFQuestions.o1Id:
@@ -463,18 +466,12 @@ async function removeInternalQuestionFile({
 
           return ok(tFo2Res);
         default:
-          throw new Error("Answer not found");
+          return err({
+            type: deleteInternalQuestionFileErrorTypes.NotFound,
+            message: "Answer not found",
+          });
       }
     case "multiple_choice":
-      // const mCQuestions = (
-      //   await db
-      //     .select()
-      //     .from(questionMultipleChoice)
-      //     .where(eq(questionMultipleChoice.questionId, questionId))
-      // )[0];
-      // if (!mCQuestions) {
-      //   throw new Error("Question not found");
-      // }
       const { data: mCQuestionsArray, error: mCQuestionsError } = await tc(
         db
           .select()
@@ -714,8 +711,6 @@ export async function deleteById(
     }
   }
 
-  // Delete the file from the db
-
   const { data: dbFileResponseArray, error: dbFileError } = await tc(
     db.delete(files).where(eq(files.id, input)).returning(),
   );
@@ -953,7 +948,6 @@ export const fileRouter = createTRPCRouter({
         // First set all the files wo are idle and storedIn !== targetStorage to queued
         // This will probably only be called if i manually move around files between storage services
 
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { error: dbInitiateStatusError } = await tc(
           db
             .update(files)
@@ -1000,7 +994,6 @@ export const fileRouter = createTRPCRouter({
           });
         }
 
-        // Then get all to be transferred files
         const { data: filesToTransfer, error: filesToTransferError } = await tc(
           db.select().from(files).where(eq(files.transferStatus, "queued")),
         );
@@ -1012,7 +1005,6 @@ export const fileRouter = createTRPCRouter({
           });
         }
 
-        // For each file, transfer it
         for (const file of filesToTransfer) {
           // Set Status
           const { error: SetStatusError } = await tc(
@@ -1071,7 +1063,6 @@ export const fileRouter = createTRPCRouter({
             });
           }
 
-          // Transfer
           switch (file.targetStorage) {
             case "utfs":
               const { data: up_utfs_response, error: up_utfs_error } = await tc(

--- a/src/server/api/routers/questions/delete.ts
+++ b/src/server/api/routers/questions/delete.ts
@@ -435,15 +435,7 @@ export const deletionRouter = createTRPCRouter({
           }
         }
       }
-      const delInternal = (
-        await db
-          .delete(questionMultipleChoice)
-          .where(eq(questionMultipleChoice.id, response.id))
-          .returning()
-      )[0];
-      if (!delInternal) {
-        throw new Error("Failed to delete question multiple choice");
-      }
+
       const { data: delInternalArray, error: dbError2 } = await tc(
         db
           .delete(questionMultipleChoice)

--- a/src/server/api/routers/wahlen.ts
+++ b/src/server/api/routers/wahlen.ts
@@ -21,53 +21,18 @@ const createWahlType = z.object({
   owner: z.string().length(32),
 });
 
-enum createWahlErrorTypes {
+enum wahlErrorTypes {
   Failed = "Failed",
   Disallowed = "Disallowed",
+  NotFound = "NotFound",
 }
 
-type createWahlError = {
-  type: createWahlErrorTypes;
+type wahlError = {
+  type: wahlErrorTypes;
   message: string;
 };
 
-export const wahlenRouter = createTRPCRouter({
-  create: protectedProcedure
-    .input(createWahlType)
-    .mutation(
-      async ({
-        input,
-      }): Promise<Result<typeof wahlen.$inferSelect, createWahlError>> => {
-        const insertable: typeof wahlen.$inferInsert = {
-          id: randomUUID(),
-          shortname: input.shortname,
-
-          title: input.title,
-          description: input.description,
-
-          owner: input.owner,
-        };
-        const { data: insertableResponse, error: insertableError } = await tc(
-          db.insert(wahlen).values(insertable).returning(),
-        );
-        if (insertableError) {
-          return err({
-            type: createWahlErrorTypes.Failed,
-            message: insertableError.message,
-          });
-        }
-
-        const response = insertableResponse[0] ? insertableResponse[0] : null;
-        if (!response) {
-          throw new Error("Failed to create wahl");
-        }
-
-        return response[0];
-      },
-    ),
-  edit: protectedProcedure
-    .input(
-      z.object({
+const editWahlType = z.object({
         id: z.string().uuid(),
         shortname: z.string().min(3).max(25).optional(),
         status: z
@@ -95,49 +60,116 @@ export const wahlenRouter = createTRPCRouter({
         archiveDate: z.date().optional(),
 
         updatedAt: z.date().optional(),
-      }),
-    )
-    .mutation(async ({ input }) => {
-      const data = await db
-        .select()
-        .from(wahlen)
-        .where(eq(wahlen.id, input.id));
+      })
 
-      if (!data[0]) {
-        throw new Error("Wahl not found");
+      
+
+export const wahlenRouter = createTRPCRouter({
+  create: protectedProcedure
+    .input(createWahlType)
+    .mutation(
+      async ({
+        input,
+      }): Promise<Result<typeof wahlen.$inferSelect, wahlError>> => {
+        const insertable: typeof wahlen.$inferInsert = {
+          id: randomUUID(),
+          shortname: input.shortname,
+
+          title: input.title,
+          description: input.description,
+
+          owner: input.owner,
+        };
+        const { data: insertableResponse, error: insertableError } = await tc(
+          db.insert(wahlen).values(insertable).returning(),
+        );
+        if (insertableError) {
+          return err({
+            type: wahlErrorTypes.Failed,
+            message: insertableError.message,
+          });
+        }
+
+        const response = insertableResponse[0] ? insertableResponse[0] : null;
+        if (!response) {
+          throw new Error("Failed to create wahl");
+        }
+
+        return ok(response);
+      },
+    ),
+  edit: protectedProcedure
+    .input(
+      editWahlType
+    )
+    .mutation(async ({ input }): Promise<Result<typeof wahlen.$inferSelect, wahlError>> => {
+
+      const {data: dataArray, error: dbError} = await tc(
+        db.select().from(wahlen).where(eq(wahlen.id, input.id)));
+      if (dbError) {
+        return err({
+          type: wahlErrorTypes.Failed,
+          message: dbError.message,
+        });
       }
+
+        const data = dataArray[0] ? dataArray[0] : null;
+        if (!data) {
+          return err({
+            type: wahlErrorTypes.Failed,
+            message: "Wahl not found",
+          });
+        }
 
       const insertable: typeof wahlen.$inferInsert = {
         id: input.id,
-        shortname: input.shortname ?? data[0].shortname,
-        status: input.status ?? data[0].status,
+        shortname: input.shortname ?? data.shortname,
+        status: input.status ?? data.status,
 
-        alert: input.alert ?? data[0].alert,
-        alertMessage: input.alertMessage ?? data[0].alertMessage,
+        alert: input.alert ?? data.alert,
+        alertMessage: input.alertMessage ?? data.alertMessage,
 
-        title: input.title ?? data[0].title,
-        description: input.description ?? data[0].description,
+        title: input.title ?? data.title,
+        description: input.description ?? data.description,
 
-        owner: input.owner ?? data[0].owner,
+        owner: input.owner ?? data.owner,
 
-        startDate: input.startDate ?? data[0].startDate,
-        endDate: input.endDate ?? data[0].endDate,
-        archiveDate: input.archiveDate ?? data[0].archiveDate,
+        startDate: input.startDate ?? data.startDate,
+        endDate: input.endDate ?? data.endDate,
+        archiveDate: input.archiveDate ?? data.archiveDate,
 
-        createdAt: data[0].createdAt,
-        updatedAt: input.updatedAt ?? data[0].updatedAt,
+        createdAt: data.createdAt,
+        updatedAt: input.updatedAt ?? data.updatedAt,
       };
 
-      const response = await db
-        .update(wahlen)
-        .set(insertable)
-        .where(eq(wahlen.id, input.id))
-        .returning();
-      if (!response[0]) {
-        throw new Error("Failed to update wahl");
+      // const response = await db
+      //   .update(wahlen)
+      //   .set(insertable)
+      //   .where(eq(wahlen.id, input.id))
+      //   .returning();
+      // if (!response[0]) {
+      //   throw new Error("Failed to update wahl");
+      // }
+
+      const { data: insertableResponse, error: insertableError } = await tc(
+        db.update(wahlen).set(insertable).where(eq(wahlen.id, input.id)).returning(),
+      );
+      if (insertableError) {
+        return err({
+          type: wahlErrorTypes.Failed,
+          message: insertableError.message,
+        });
       }
 
-      return response[0];
+      const response = insertableResponse[0] ? insertableResponse[0] : null;
+      if (!response) {
+        return err({
+          type: wahlErrorTypes.Failed,
+          message: "Failed to update wahl",
+        });
+      }
+
+      return ok(response)
     }),
   getByShortname: publicProcedure.query(() => ""),
 });


### PR DESCRIPTION
# Refactor Error Handling with Neverthrow

## Small info: This is the Export of my Codespace witch ran out of hours

This PR replaces direct error throwing with structured error handling using the Neverthrow library across multiple routers:

- In `files.ts`, replaced thrown errors with proper error return objects using the Neverthrow pattern
- In `questions/delete.ts`, removed redundant code that was already handled by the try-catch wrapper
- In `wahlen.ts`, implemented comprehensive Neverthrow error handling:
  - Added proper error types enum and error type definition
  - Converted direct DB operations to use the try-catch wrapper
  - Replaced thrown errors with structured error returns
  - Added proper type annotations for function returns

These changes improve error handling consistency and provide better type safety throughout the codebase.